### PR TITLE
Generate to stdout and given file

### DIFF
--- a/generator.cc
+++ b/generator.cc
@@ -17,8 +17,13 @@ static std::ifstream open_config_file(const std::string path) {
 }
 
 static std::string out_name(json const& config) {
+    auto fname_it = config.find("file-name");
+    if (fname_it != config.end()){
+        return fname_it;
+    }
+
     std::stringstream ss;
-    json config_ref = config;
+    json config_ref = config.at("stream");
     // this allows finding name hidden in postprocessing streams
     while (config_ref.find("algorithm") == config_ref.end()) {
         config_ref = config_ref.at("source");
@@ -38,7 +43,7 @@ generator::generator(json const& config)
     : _config(config)
     , _seed(seed::create(config.at("seed")))
     , _tv_count(config.at("tv-count"))
-    , _o_file_name(out_name(config.at("stream"))) {
+    , _o_file_name(out_name(config)) {
 
     seed_seq_from<pcg32> main_seeder(_seed);
 

--- a/generator.cc
+++ b/generator.cc
@@ -19,7 +19,7 @@ static std::ifstream open_config_file(const std::string path) {
 static std::string out_name(json const& config) {
     auto fname_it = config.find("file-name");
     if (fname_it != config.end()){
-        return fname_it;
+        return *fname_it;
     }
 
     std::stringstream ss;
@@ -52,11 +52,20 @@ generator::generator(json const& config)
 
 void generator::generate() {
 
-    std::ofstream o_file(_o_file_name, std::ios::binary);
+    auto stdout_it = _config.find("stdout");
+    std::unique_ptr<std::ostream> ofstream_ptr;
+    std::ostream * o_file = nullptr;
+
+    if (stdout_it == _config.end() || stdout_it->get<bool>() == false){
+        ofstream_ptr = std::make_unique<std::ofstream>(_o_file_name, std::ios::binary);
+        o_file = ofstream_ptr.get();
+    } else {
+        o_file = &(std::cout);
+    }
 
     for (std::size_t i = 0; i < _tv_count; ++i) {
         vec_cview n = _stream_a->next();
         for (auto o : n)
-            o_file << o;
+            *o_file << o;
     }
 }

--- a/main.cc
+++ b/main.cc
@@ -25,11 +25,11 @@ int main(const int argc, const char** argv) try {
     auto cfg = options.parse(make_view(argv, argc));
 
     if (cfg.help) {
-        std::cout << "Usage: eacirc-streams [options]" << std::endl;
+        std::cerr << "Usage: eacirc-streams [options]" << std::endl;
 
-        options.print(std::cout);
+        options.print(std::cerr);
     } else if (cfg.version) {
-        std::cout << "Generator version " VERSION_TAG << std::endl;
+        std::cerr << "Generator version " VERSION_TAG << std::endl;
     } else {
         test_environment();
 


### PR DESCRIPTION
This PR adds feature to generate data to stdout or to a file given in the configuration file.

Stdout is quite handy to redirect the stream directly to Booltest on diskless machines or to another post-processing tools.

Specifying filename in the config file is also handy so the user knows which file to look for after generator finishes.