### PR TITLE
Cmake always builds generator binary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,26 +12,12 @@ matrix:
           packages: ['g++-5']
       env: [CC_COMPILER=gcc-5, CXX_COMPILER=g++-5, BUILD_testsuite=ON, TEST_COMMAND=./testsuite]
     - os: linux
-      compiler: gcc-5
-      addons:
-        apt:
-          sources: ['ubuntu-toolchain-r-test']
-          packages: ['g++-5']
-      env: [CC_COMPILER=gcc-5, CXX_COMPILER=g++-5, BUILD_testsuite=OFF]
-    - os: linux
       compiler: clang-3.7
       addons:
         apt:
           sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.7']
           packages: ['g++-5', 'clang-3.7']
       env: [CC_COMPILER=clang-3.7, CXX_COMPILER=clang++-3.7, BUILD_testsuite=ON, TEST_COMMAND=./testsuite]
-    - os: linux
-      compiler: clang-3.7
-      addons:
-        apt:
-          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.7']
-          packages: ['g++-5', 'clang-3.7']
-      env: [CC_COMPILER=clang-3.7, CXX_COMPILER=clang++-3.7, BUILD_testsuite=OFF]
 
 before_script:
   - wget --no-check-certificate https://cmake.org/files/v3.5/cmake-3.5.2-Linux-x86_64.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,10 +25,14 @@ endif()
 
 
 # === Provide sources as library
-add_library(eacirc-streams-lib STATIC
+set(eacirc-streams-sources
         stream.h
         streams.h
         streams.cc
+        )
+
+add_library(eacirc-streams-lib STATIC
+        ${eacirc-streams-sources}
         )
 
 set_target_properties(eacirc-streams-lib PROPERTIES
@@ -47,30 +51,30 @@ add_subdirectory(streams/block)
 
 option(BUILD_testsuite "Build all tests." OFF)
 
+# === eacirc generator executable
+add_executable(eacirc-streams main.cc generator)
+
+set_target_properties(eacirc-streams PROPERTIES
+        LINKER_LANGUAGE CXX
+        )
+
+target_link_libraries(eacirc-streams eacirc-core eacirc-streams-lib)
+
+build_stream(eacirc-streams estream)
+build_stream(eacirc-streams sha3)
+build_stream(eacirc-streams block)
+
 ##############
 # Building of testsuite
 ##############
-if (NOT BUILD_testsuite)
 
-    # === eacirc generator executable
-    add_executable(eacirc-streams main.cc generator)
-
-    set_target_properties(eacirc-streams PROPERTIES
-            LINKER_LANGUAGE CXX
-            )
-
-    target_link_libraries(eacirc-streams eacirc-core eacirc-streams-lib)
-
-    build_stream(eacirc-streams estream)
-    build_stream(eacirc-streams sha3)
-    build_stream(eacirc-streams block)
-
-else()
+if (BUILD_testsuite)
     enable_testing()
     include_directories(${gtest_SOURCE_DIR}/include ${gtest_SOURCE_DIR})
 
     # === testsuite executable
     add_executable(testsuite
+            ${eacirc-streams-sources}
             testsuite/test_main.cc
             testsuite/stream_tests.cc
             testsuite/sha3_streams_tests.cc
@@ -83,13 +87,15 @@ else()
             testsuite/test-utils/common_functions
             testsuite/test-utils/test_case.h)
 
+    target_compile_definitions(testsuite PUBLIC "TEST_STREAM=1")
+
     file(COPY testsuite/test-resources DESTINATION resources)
 
     # Standard linking to gtest stuff.
     target_link_libraries(testsuite gtest gtest_main)
 
     # Extra linking for the project.
-    target_link_libraries(testsuite eacirc-core eacirc-streams-lib)
+    target_link_libraries(testsuite eacirc-core)
 
     build_stream(testsuite estream)
     build_stream(testsuite sha3)

--- a/streams.cc
+++ b/streams.cc
@@ -213,7 +213,7 @@ make_stream(const json& config, default_seed_source& seeder, const std::size_t o
         const std::size_t pos = std::size_t(config.at("position"));
         return std::make_unique<column_fixed_position_stream>(config, seeder, osize, pos);
     }
-#ifdef BUILD_testsuite
+#if (BUILD_testsuite && TEST_STREAM)
     else if (type == "test-stream")
         return std::make_unique<testsuite::test_stream>(config);
 #endif


### PR DESCRIPTION
I had quite a struggle to develop in CLion with the current CMake with both generator and testsuite binaries. So I changed CMake so it always builds the generator binary. It is possible to build both testsuite and generator binary in one run. This simplifies a development for me as I can have both enabled and debug.

Thanks for considering a merge.