### PR TITLE
fix: DES, 3DES rekeying

### DIFF
--- a/streams/block/ciphers/des/single_des.cpp
+++ b/streams/block/ciphers/des/single_des.cpp
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 #include <stdexcept>
+#include <memory>
 
 namespace block {
 bool single_des_next_bit(const std::uint8_t* key, const unsigned i) {
@@ -14,6 +15,8 @@ void single_des::keysetup(const std::uint8_t* key, const std::uint64_t keysize) 
     if (keysize != 7) {
         throw std::runtime_error("DES keysize has to be 7 B long.");
     }
+
+    memset(_ctx.key, 0, sizeof(uint8_t) * 8);
     for (unsigned i = 0; i < 7 * 8; ++i) {
         const unsigned byte_pos = 7 - (i / 7);
         _ctx.key[byte_pos] |= single_des_next_bit(key, i) << ((i % 7) + 1);

--- a/streams/block/ciphers/des/triple_des.cpp
+++ b/streams/block/ciphers/des/triple_des.cpp
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 #include <stdexcept>
+#include <memory>
 
 namespace block {
 bool triple_des_next_bit(const std::uint8_t* key, const unsigned i) {
@@ -14,6 +15,8 @@ void triple_des::keysetup(const std::uint8_t* key, const std::uint64_t keysize) 
     if (keysize != 21) {
         throw std::runtime_error("3-DES keysize has to be 21 B long.");
     }
+
+    memset(_ctx.key, 0, sizeof(uint8_t) * 24);
     for (unsigned i = 0; i < 21 * 8; ++i) {
         const unsigned byte_pos = 23 - (i / 7);
         _ctx.key[byte_pos] |= triple_des_next_bit(key, i) << ((i % 7) + 1);


### PR DESCRIPTION
Re-keying was not working as the key setup was using OR to set bits to existing context. 